### PR TITLE
Fix SDK_VERSION component of release.sh

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -4,7 +4,7 @@ set -ex
 
 VERSION=$(cat version)
 
-sed -i "" -e "s/const SDK_VERSION = '[[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*';/const SDK_VERSION = '$VERSION';/g" src/index.jsx
+sed -i "" -e "s/const SDK_VERSION = \"[[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*\";/const SDK_VERSION = \"$VERSION\";/g" src/index.jsx
 sed -i "" -e "s/  \"version\": \"[[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*\",/  \"version\": \"$VERSION\",/g" package.json
 
 git add package.json src/index.jsx version


### PR DESCRIPTION
This has been broken for quite some time, resulting in our current `SDK_VERSION` (`0.0.10`) being out of sync with the true `version` (`0.0.12`).