### PR TITLE
Allow React 18 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/berbix/berbix-react#readme",
   "peerDependencies": {
-    "react": "^16.8 || ^17"
+    "react": "^16.8 || ^17 || ^18"
   },
   "dependencies": {
     "prop-types": "^15.7.2"


### PR DESCRIPTION
For React 18 apps, a peer dependency warning would show when installing package dependencies, e.g.:

```
warning " > berbix-react@1.0.3" has incorrect peer dependency "react@^16.8 || ^17".
```

This didn't seem to affect functionality; `berbix-react` worked just fine in a React 18 app. But we should bump up the allowed React peer dependency versions so that we don't get this warning any more.